### PR TITLE
Fix goroutine leak

### DIFF
--- a/nats/discover.go
+++ b/nats/discover.go
@@ -335,6 +335,7 @@ func (nats *NATS) performTransactionWith(c *turn.Client, changeIP, changePort bo
 				nats.dfErr = fmt.Errorf("CHANGE-REQUEST ignored (IP)")
 				nats.mu.Unlock()
 				receivedCh <- false
+				return
 			}
 		}
 		if changePort {
@@ -343,6 +344,7 @@ func (nats *NATS) performTransactionWith(c *turn.Client, changeIP, changePort bo
 				nats.dfErr = fmt.Errorf("CHANGE-REQUEST ignored (Port)")
 				nats.mu.Unlock()
 				receivedCh <- false
+				return
 			}
 		}
 


### PR DESCRIPTION
The missing returns here create a blocked send on `receivedCh` which cause the goroutine to hang open indefinitely.