### PR TITLE
Fix second goroutine leak

### DIFF
--- a/nats/discover.go
+++ b/nats/discover.go
@@ -335,6 +335,7 @@ func (nats *NATS) performTransactionWith(c *turn.Client, changeIP, changePort bo
 				nats.dfErr = fmt.Errorf("CHANGE-REQUEST ignored (IP)")
 				nats.mu.Unlock()
 				receivedCh <- false
+				return
 			}
 		}
 		if changePort {
@@ -343,6 +344,7 @@ func (nats *NATS) performTransactionWith(c *turn.Client, changeIP, changePort bo
 				nats.dfErr = fmt.Errorf("CHANGE-REQUEST ignored (Port)")
 				nats.mu.Unlock()
 				receivedCh <- false
+				return
 			}
 		}
 

--- a/nats/discover.go
+++ b/nats/discover.go
@@ -150,6 +150,7 @@ func (nats *NATS) Discover() (*DiscoverResult, error) {
 		var maddr stun.XORMappedAddress
 		if err = maddr.GetFrom(trRes.Msg); err != nil {
 			if err != nil {
+				<-filterDiscovDone
 				return nil, fmt.Errorf("XOR-MAPPED-ADDRESS not found")
 			}
 		}
@@ -167,6 +168,7 @@ func (nats *NATS) Discover() (*DiscoverResult, error) {
 			var caddr attrAddress
 			if err = caddr.getAs(trRes.Msg, attrTypeChangedAddress); err != nil {
 				if err != nil {
+					<-filterDiscovDone
 					return nil, fmt.Errorf("CHANGED-ADDRESS not found")
 				}
 			}


### PR DESCRIPTION
Before returning early from the `Discover` function, you have to drain the `FilterDiscovDone` channel, otherwise it leaks `discoverFilteringBehavior` goroutines.